### PR TITLE
Updated pandas version to 1.5.3 to resolve error

### DIFF
--- a/labs/Lab_Data_Analytics/requirements.txt
+++ b/labs/Lab_Data_Analytics/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.26
-pandas==1.4.3
+pandas==1.5.3
 plotly==5.9.0
 pyodbc==4.0.35
 streamlit==1.20.0


### PR DESCRIPTION
Modified requirements.txt to bump pandas to version 1.5.3 to address a module installation error when customers are using Python 3.11.x installations. 1.5.3 has been used in two OpenAI Workshops and does not appear to have any negative impact on the Data Analytics lab demo.